### PR TITLE
Add requirements.txt, closes #1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+youtube_dl
+requests==2.10.0


### PR DESCRIPTION
requests is required to be at 2.10.0 due to a change to encoding that was recently introduced.